### PR TITLE
List "aio" as potential alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ The easiest way to install this plugin is to use [Oh My Zsh](https://github.com/
 | Alias                | Command                                         |
 |:---------------------|:------------------------------------------------|
 | `air`                | `$AIR_DEV_PATH/tools/aio.sh`                    |
+| `aio`                | `$AIR_DEV_PATH/tools/aio.sh`                    |
 | `dca`                | `$AIR_DEV_PATH/tools/aio.sh`                    |

--- a/zsh-air.plugin.zsh
+++ b/zsh-air.plugin.zsh
@@ -1,5 +1,6 @@
 # aliases
 alias air=$AIR_DEV_PATH/tools/aio.sh
+alias aio=$AIR_DEV_PATH/tools/aio.sh
 alias dca=$AIR_DEV_PATH/tools/aio.sh
 
 function listAirCompletions {


### PR DESCRIPTION
In the help setup guide "aio" is listed as potential alias so lets list that in the script as well for a single-place-config of aliases.